### PR TITLE
Create mobile header

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -8,7 +8,7 @@ export default function Header() {
     <HeaderElement>
       <HeaderStart>
         <Link href="/">
-        <Image src="/images/surfer.png" alt="surfer" />
+          <Image src="/images/surfer.png" alt="surfer" />
         </Link>
         <HeaderItems>
           <HeaderItem content="Docs" link="/docs" />
@@ -30,12 +30,16 @@ export default function Header() {
 }
 
 const HeaderElement = styled.header`
+  @media (max-width: 1022px) {
+    display: none;
+  }
+
   display: flex;
   flex-direction: row;
   justify-content: space-between;
   width: 100;
   margin-bottom: 3rem;
-  
+
   --margin-x: 7vw;
   margin-left: var(--margin-x);
   margin-right: var(--margin-x);

--- a/components/MobileHeader.js
+++ b/components/MobileHeader.js
@@ -1,1 +1,119 @@
-//TODO: Create mobile header
+import styled from "@emotion/styled";
+import Link from "next/link";
+import { useState } from "react";
+
+export default function MobileHeader() {
+  const [showMenu, setshowMenu] = useState(false);
+
+  return (
+    <Wrapper>
+      <HeaderElement>
+        <MenuButton onClick={() => setshowMenu(!showMenu)}>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="24"
+            height="24"
+            stroke-width="2"
+            stroke="currentColor"
+            fill="none"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <path d="M0 0h24v24H0z" stroke="none" />
+            <path d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+        </MenuButton>
+        <Link href="/">
+          <Image src="/images/surfer.png" alt="surfer" />
+        </Link>
+        <Link href="https://github.com/surfcodes/surf">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="24"
+            height="24"
+            stroke-width="2"
+            stroke="currentColor"
+            fill="none"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <path d="M0 0h24v24H0z" stroke="none" />
+            <path d="M9 19c-4.3 1.4-4.3-2.5-6-3m12 5v-3.5c0-1 .1-1.4-.5-2 2.8-.3 5.5-1.4 5.5-6a4.6 4.6 0 00-1.3-3.2 4.2 4.2 0 00-.1-3.2s-1.1-.3-3.5 1.3a12.3 12.3 0 00-6.2 0C6.5 2.8 5.4 3.1 5.4 3.1a4.2 4.2 0 00-.1 3.2A4.6 4.6 0 004 9.5c0 4.6 2.7 5.7 5.5 6-.6.6-.6 1.2-.5 2V21" />
+          </svg>
+        </Link>
+      </HeaderElement>
+      <Menu className={showMenu ? "open" : null}>
+        <MenuItem>
+          <Link href="/">Home</Link>
+        </MenuItem>
+        <MenuItem>
+          <Link href="docs">Docs</Link>
+        </MenuItem>
+        <MenuItem>
+          <Link href="blog">Blog</Link>
+        </MenuItem>
+      </Menu>
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled.div`
+  margin-bottom: 3rem;
+`;
+
+const HeaderElement = styled.header`
+  @media (max-width: 1022px) {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    width: 100;
+
+    --margin-x: 0.5rem;
+    margin-left: var(--margin-x);
+    margin-right: var(--margin-x);
+
+    background: #fff;
+    padding: 1rem 1.25rem;
+  }
+
+  display: none;
+`;
+
+const Image = styled.img`
+  width: 26px;
+  height: 26px;
+`;
+
+const Menu = styled.nav`
+  display: none;
+`;
+
+const MenuButton = styled.button`
+  background: none;
+  color: inherit;
+  border: none;
+  padding: 0.25rem;
+  cursor: pointer;
+  font: inherit;
+  outline: inherit;
+
+  display: flex;
+  align-items: center;
+
+  border-radius: 0.4rem;
+
+  &:hover {
+    background: #e5e7eb;
+  }
+`;
+
+const MenuItem = styled.span`
+  padding: 0.8rem;
+  margin: 0.2rem 0;
+
+  border-radius: 0.5rem;
+
+  &:hover {
+    background: #f3f4f6;
+  }
+`;

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -2,11 +2,14 @@ import "../styles/globals.css";
 import styled from "@emotion/styled";
 
 import Header from "components/Header";
+import MobileHeader from "components/MobileHeader";
+
 
 function MyApp({ Component, pageProps }) {
   return (
     <Page>
       <Header />
+      <MobileHeader />
       <Component {...pageProps} />
     </Page>
   );

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -34,3 +34,23 @@ a {
 * {
   box-sizing: border-box;
 }
+
+nav.open {
+  display: flex;
+  flex-direction: column;
+
+  border-radius: 0.6rem;
+
+  --margin-x: 0.5rem;
+  margin-left: var(--margin-x);
+  margin-right: var(--margin-x);
+
+  --padding-x: 2rem;
+  padding-left: var(--padding-x);
+  padding-right: var(--padding-x);
+
+  padding-bottom: 2rem;
+
+  box-shadow: 0 0 #0000, 0 0 #0000, 0 20px 25px -5px rgba(0, 0, 0, 0.1),
+    0 10px 10px -5px rgba(0, 0, 0, 0.04);
+}


### PR DESCRIPTION
This brings the mobile header to the page. I oriented the design on the figma template but:
- I used different icons ([Tabler Icons](https://tabler-icons.io/))
- I couldn't find any design for the opened menu, so I designed it myself
- I used `1022px` as breakpoint for switching from desktop to mobile menu

Hope this is ok, but if you got any objections, please let me know.